### PR TITLE
asynchronous mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/Asynchronous/NSManagedObjectContext+DCTAsynchronousTasks.m
+++ b/Asynchronous/NSManagedObjectContext+DCTAsynchronousTasks.m
@@ -189,13 +189,13 @@
 			[objectIDs addObject:[mo objectID]];
 	}
 	
-	NSManagedObjectContext *threadedContext = [[NSManagedObjectContext alloc] init];
-	[threadedContext setPersistentStoreCoordinator:[self persistentStoreCoordinator]];
-	
 	dispatch_queue_t asyncQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	
 	dispatch_async(asyncQueue, ^{
 		
+        NSManagedObjectContext *threadedContext = [[NSManagedObjectContext alloc] init];
+        [threadedContext setPersistentStoreCoordinator:[self persistentStoreCoordinator]];
+        
 		NSArray *threadedObjects = nil;
 		if (objectIDs) {
 			NSMutableArray *array = [NSMutableArray arrayWithCapacity:[objectIDs count]];
@@ -246,13 +246,13 @@
 				   withCallbackQueue:(dispatch_queue_t)callbackQueue
 							   block:(DCTFetchRequestCallbackBlock)callbackBlock {
 	
-	NSManagedObjectContext *threadedContext = [[NSManagedObjectContext alloc] init];
-	[threadedContext setPersistentStoreCoordinator:[self persistentStoreCoordinator]];
-	
 	dispatch_queue_t asyncQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	
 	dispatch_async(asyncQueue, ^{
 		
+        NSManagedObjectContext *threadedContext = [[NSManagedObjectContext alloc] init];
+        [threadedContext setPersistentStoreCoordinator:[self persistentStoreCoordinator]];
+        
 		NSError *error = nil;
 		NSArray *array = [threadedContext executeFetchRequest:fetchRequest error:&error];
 		


### PR DESCRIPTION
Hi,

I've seen some edge case errors which (I think) are to do with not creating contexts in the thread where they will be used. I noticed the dct_ async stuff uses the same pattern, so have made the same change there, if you want to pull the change.

Cheers,
Frank

(See Apple docs here: https://developer.apple.com/library/ios/#documentation/cocoa/conceptual/CoreData/Articles/cdConcurrency.htm 
"You must create the managed context on the thread on which is will be used. If you use NSOperation, note that its init method is invoked on the same thread as the caller. You must not, therefore, create a managed object context for the queue in the queue’s init method, otherwise it is associated with the caller’s thread. Instead, you should create the context in main (for a serial queue) or start (for a concurrent queue).")
